### PR TITLE
Update main_window.tabs.ui

### DIFF
--- a/deluge/ui/gtk3/glade/main_window.tabs.ui
+++ b/deluge/ui/gtk3/glade/main_window.tabs.ui
@@ -238,7 +238,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="label" translatable="yes">Down Speed:</property>
+                                <property name="label" translatable="yes">Uploaded:</property>
                                 <attributes>
                                   <attribute name="weight" value="bold"/>
                                 </attributes>
@@ -283,7 +283,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
-                                <property name="label" translatable="yes">Uploaded:</property>
+                                <property name="label" translatable="yes">Down Speed:</property>
                                 <attributes>
                                   <attribute name="weight" value="bold"/>
                                 </attributes>


### PR DESCRIPTION
Some labels were showing wrong stats ("Down speed" was showing stats for "uploaded" and vice versa)  so i swapped them. 
Please do help me check to confirm whether I am correct.

![torrent thingy](https://github.com/DanielHuey/deluge/assets/33962088/ab7085a0-7a9a-400c-9ec2-7dded2b11f9f)
The image above shows an example of the current stats shown by "Uploaded:" and "Down Speed:" before this patch.
